### PR TITLE
Updated sentry version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+vendor

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/raven"]
-	path = vendor/raven
-	url = git://github.com/getsentry/raven-php.git

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@ Sentry Client for TYPO3
 
 This is a TYPO3 Extension for exception logging with sentry, see http://www.getsentry.com
 
-It's based on https://github.com/getsentry/raven-php
+It's based on https://github.com/getsentry/sentry-php
 
 Installation
 ------------
-	$ git clone --recursive https://github.com/networkteam/sentry_client.git
+
+**Via composer:**
+```bash
+$ composer require networkteam/sentry_client
+```
 
 It's also available in TER: http://typo3.org/extensions/repository/view/sentry_client
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "networkteam/sentry_client",
+  "description": "Sentry Client for TYPO3",
+  "minimum-stability": "dev",
+  "license": "LGPL-3.0",
+  "authors": [
+    {
+      "name": "Christoph Lehmann",
+      "email": "christoph.lehmann@networkteam.com"
+    },
+    {
+      "name": "Michael Grundkötter",
+      "email": "mg@ujamii.com"
+    }
+  ],
+  "require": {
+    "sentry/sentry": "1.6.x"
+  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,79 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "9b11a9c198e57ed6b13ec0aa357c75a5",
+    "packages": [
+        {
+            "name": "sentry/sentry",
+            "version": "1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "5bee26136ab3fc166334cd972892bf71bd361558"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/5bee26136ab3fc166334cd972892bf71bd361558",
+                "reference": "5bee26136ab3fc166334cd972892bf71bd361558",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.2.4"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.8.0",
+                "monolog/monolog": "*",
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "suggest": {
+                "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
+            },
+            "bin": [
+                "bin/sentry"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Raven_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "David Cramer",
+                    "email": "dcramer@gmail.com"
+                }
+            ],
+            "description": "A PHP client for Sentry (http://getsentry.com)",
+            "homepage": "http://getsentry.com",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "time": "2017-02-03 07:32:53"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,15 +1,17 @@
 <?php
-
 if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
 if (!function_exists('register_client')) {
 	function register_client() {
-		$autoloadPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('sentry_client') . 'vendor/autoload.php';
+		$extPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('sentry_client');
+		$autoloadPath = $extPath . 'vendor/autoload.php';
 		if (is_readable($autoloadPath)) {
 			require_once $autoloadPath;
 		}
+		require_once $extPath . 'Classes/Client.php';
+
 		$client = new \Lemming\SentryClient\Client();
 		$errorHandler = new Raven_ErrorHandler($client, TRUE);
 		$errorHandler->registerExceptionHandler();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,9 +6,10 @@ if (!defined('TYPO3_MODE')) {
 
 if (!function_exists('register_client')) {
 	function register_client() {
-		$ravenPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('sentry_client') . 'vendor/raven/lib/Raven';
-		require_once($ravenPath . '/Autoloader.php');
-		\Raven_Autoloader::register();
+		$autoloadPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('sentry_client') . 'vendor/autoload.php';
+		if (is_readable($autoloadPath)) {
+			require_once $autoloadPath;
+		}
 		$client = new \Lemming\SentryClient\Client();
 		$errorHandler = new Raven_ErrorHandler($client, TRUE);
 		$errorHandler->registerExceptionHandler();


### PR DESCRIPTION
I updated the dependency to the now supported official package to prevent warnings in current sentry version (outdated api call). I also switched form git submodule to composer, but the TER package has to contain the whole vendor folder anyways.