### PR TITLE
[TASK] TYPO3 9.5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   ],
   "require": {
     "sentry/sentry": "1.9.*",
-    "typo3/cms-core": "^8.7"
+    "typo3/cms-core": "^8.7 || ^9.5"
   },
   "extra": {
     "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends' =>
                 [
-                    'typo3' => '8.7.0-8.7.99',
+                    'typo3' => '8.7.0-9.5.99',
                 ],
             'conflicts' => [],
             'suggests' => []


### PR DESCRIPTION
Raise compatibility to TYPO3 9.5

I tested the basic functionality with TYPO3 v9.5 and could not find any issues. 