### PR TITLE
Getting the extension configuration uses the TYPO3 v9 way

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -2,7 +2,9 @@
 
 namespace Networkteam\SentryClient\Service;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use Networkteam\SentryClient\Client;
 
 class ConfigurationService implements \TYPO3\CMS\Core\SingletonInterface
@@ -53,7 +55,11 @@ class ConfigurationService implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected static function getExtensionConfiguration($key)
     {
-        $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['sentry_client']);
+        if (VersionNumberUtility::convertVersionStringToArray(VersionNumberUtility::getCurrentTypo3Version())['version_main'] < 9) {
+            $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['sentry_client']);
+        } else {
+            $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('sentry_client');
+        }
 
         if (is_array($extensionConfiguration) && array_key_exists($key, $extensionConfiguration)) {
             return $extensionConfiguration[$key];


### PR DESCRIPTION
In TYPO3 v9 the extension configuration is stored in LocalConfiguration.php under the EXTENSIONS key. The old way with the EXT key is deprecated. This patch introduces the ExtensionConfiguration class if TYPO3 v9 is used.