### PR TITLE
Bugfix: Set real client IP from TYPO3 environment variables

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -27,7 +27,7 @@ class Client extends \Raven_Client
         $this->tags_context(array(
             'typo3_version' => TYPO3_version,
             'typo3_mode' => TYPO3_MODE,
-            'application_context' => \TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext()->__toString(),
+            'application_context' => GeneralUtility::getApplicationContext()->__toString(),
         ));
 
         $reportUserInformation = ConfigurationService::getReportUserInformation();
@@ -50,6 +50,7 @@ class Client extends \Raven_Client
                 $this->user_context($userContext);
             }
         }
+        $this->user_context(['ip_address' => GeneralUtility::getIndpEnv('REMOTE_ADDR')]);
 
         return parent::captureException($exception, $culprit_or_options, $logger, $vars);
     }


### PR DESCRIPTION
Use GeneralUtility::getIndpEnv() to set the client remote address from
TYPO3 system environment variables to provide proper address on proxied
requests.

Resolves #26 