### PR TITLE
Bugfix: Correct return type when DSN is not defined

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -36,6 +36,8 @@ class Client implements SingletonInterface
 
             return $eventId;
         }
+
+        return null;
     }
 
     protected static function setUserContext(): void


### PR DESCRIPTION
When a DSN is not defined in the extension configuration
and Client::captureException() is called the following
error occurs:

Uncaught TYPO3 Exception: Return value of Networkteam\SentryClient\Client::captureException() must be of the type string or null, none returned | TypeError thrown in file /xxx/typo3conf/ext/sentry_client/Classes/Client.php in line 39.