### PR TITLE
Add LogWriter for reporting messages which are normally just logged

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -91,7 +91,7 @@ class Client implements SingletonInterface
         });
     }
 
-    public static function captureMessage(string $message, $loglevel = 'info'): ?string
+    public static function captureMessage(string $message, string $loglevel = 'info'): ?string
     {
         return captureMessage($message, self::createSeverity($loglevel));
     }

--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -1,39 +1,57 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 namespace Networkteam\SentryClient;
 
 use Networkteam\SentryClient\Service\ConfigurationService;
 use Networkteam\SentryClient\Service\ExceptionBlacklistService;
+use Sentry\Severity;
 use Sentry\State\Scope;
+use TYPO3\CMS\Core\Log\LogLevel;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use function Sentry\captureException;
+use function Sentry\captureMessage;
 use function Sentry\configureScope;
 use function Sentry\init;
 
 class Client implements SingletonInterface
 {
-    /**
-     * Log an exception to sentry
-     */
-    public static function captureException(\Throwable $exception): ?string
-    {
-        $dsn = ConfigurationService::getDsn();
-        if (!empty($dsn) && ExceptionBlacklistService::shouldHandleException($exception)) {
+    protected static $initialized = false;
 
+    public static function init(): bool
+    {
+        if (self::$initialized) {
+            return true;
+        }
+
+        $dsn = ConfigurationService::getDsn();
+        if (!empty($dsn)) {
             $options['dsn'] = $dsn;
             if (ConfigurationService::getRelease()) {
                 $options['release'] = ConfigurationService::getRelease();
             }
             $options['environment'] = ConfigurationService::getEnvironment();
-            $options['error_types'] = E_ALL ^ E_NOTICE;
+            $options['error_types'] = E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_USER_DEPRECATED;
             $options['project_root'] = ConfigurationService::getProjectRoot();
             init($options);
 
             self::setUserContext();
             self::setTagsContext();
-            $eventId = captureException($exception);
+            self::$initialized = true;
 
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Log an exception to sentry
+     */
+    public static function captureException(\Throwable $exception): ?string
+    {
+        if (self::init() && ExceptionBlacklistService::shouldHandleException($exception)) {
+            $eventId = captureException($exception);
             return $eventId;
         }
 
@@ -74,5 +92,37 @@ class Client implements SingletonInterface
                 'typo3_mode' => TYPO3_MODE
             ]);
         });
+    }
+
+    public static function captureMessage($message, $loglevel)
+    {
+        captureMessage($message, self::createSeverity($loglevel));
+    }
+
+    protected static function createSeverity($loglevel): Severity
+    {
+        switch ($loglevel) {
+            case LogLevel::EMERGENCY:
+                $severityValue = Severity::FATAL;
+                break;
+            case LogLevel::ALERT:
+                $severityValue = Severity::FATAL;
+                break;
+            case LogLevel::CRITICAL:
+                $severityValue = Severity::FATAL;
+                break;
+            case LogLevel::ERROR:
+                $severityValue = Severity::ERROR;
+                break;
+            case LogLevel::WARNING:
+                $severityValue = Severity::WARNING;
+                break;
+            case LogLevel::INFO:
+                $severityValue = Severity::INFO;
+                break;
+            case LogLevel::NOTICE:
+                $severityValue = Severity::INFO;
+        }
+        return new Severity($severityValue);
     }
 }

--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -45,9 +45,6 @@ class Client implements SingletonInterface
         return false;
     }
 
-    /**
-     * Log an exception to sentry
-     */
     public static function captureException(\Throwable $exception): ?string
     {
         if (self::init() && ExceptionBlacklistService::shouldHandleException($exception)) {
@@ -94,20 +91,16 @@ class Client implements SingletonInterface
         });
     }
 
-    public static function captureMessage($message, $loglevel)
+    public static function captureMessage(string $message, $loglevel = 'info'): ?string
     {
-        captureMessage($message, self::createSeverity($loglevel));
+        return captureMessage($message, self::createSeverity($loglevel));
     }
 
-    protected static function createSeverity($loglevel): Severity
+    protected static function createSeverity(string $loglevel): Severity
     {
         switch ($loglevel) {
             case LogLevel::EMERGENCY:
-                $severityValue = Severity::FATAL;
-                break;
             case LogLevel::ALERT:
-                $severityValue = Severity::FATAL;
-                break;
             case LogLevel::CRITICAL:
                 $severityValue = Severity::FATAL;
                 break;
@@ -117,10 +110,7 @@ class Client implements SingletonInterface
             case LogLevel::WARNING:
                 $severityValue = Severity::WARNING;
                 break;
-            case LogLevel::INFO:
-                $severityValue = Severity::INFO;
-                break;
-            case LogLevel::NOTICE:
+            default:
                 $severityValue = Severity::INFO;
         }
         return new Severity($severityValue);

--- a/Classes/SentryLogWriter.php
+++ b/Classes/SentryLogWriter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Networkteam\SentryClient;
+
+use Sentry\State\Scope;
+use TYPO3\CMS\Core\Log\LogRecord;
+use TYPO3\CMS\Core\Log\Writer\AbstractWriter;
+use function Sentry\withScope;
+
+class SentryLogWriter extends AbstractWriter
+{
+    public function writeLog(LogRecord $record)
+    {
+        if (Client::init()) {
+            withScope(function (Scope $scope) use ($record): void {
+                $scope->setExtra('component', $record->getComponent());
+                if ($record->getData()) {
+                    $scope->setExtra('data', $record->getData());
+                }
+                $scope->setTag('source', 'logwriter');
+
+                Client::captureMessage($record->getMessage(), $record->getLevel());
+            });
+        }
+    }
+}

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -24,6 +24,8 @@ class ConfigurationService
 
     const SHOW_EVENT_ID = 'showEventId';
 
+    const LOGWRITER_LOGLEVEL = 'logWriterLogLevel';
+
     /**
      * @param $path
      * @return mixed
@@ -88,5 +90,9 @@ class ConfigurationService
 
     public static function showEventId() {
         return (bool)self::getExtensionConfiguration(self::SHOW_EVENT_ID);
+    }
+
+    public static function getLogWriterLevel() {
+        return self::getExtensionConfiguration(self::LOGWRITER_LOGLEVEL);
     }
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ SetEnv SENTRY_ENVIRONMENT Staging
 * Ignore database connection errors (they should better be handled by a monitoring system)
 * Report user information: Select one of `none` | `userid` | `usernameandemail`
 * Blacklist exception message regular expression 
+* LogWriter Loglevel: If set, messages are reported which normally are just logged  
 
 ## How to test the connection to Sentry?
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -12,3 +12,5 @@ reportDatabaseConnectionErrors = 0
 release =
 # cat=Sentry/; type=boolean; label=Show Event id
 showEventId = 1
+# cat=Sentry/; type=options[,warning,error]; label=LogWriter level: The LogWriter reports errors which are normally just logged
+logWriterLogLevel = error

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,3 +12,13 @@ if (!\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Frontend\ContentObject\Exception\ProductionExceptionHandler::class] = [
     'className' => \Networkteam\SentryClient\Content\ProductionExceptionHandler::class
 ];
+
+$sentryLogWriterLevel = \Networkteam\SentryClient\Service\ConfigurationService::getLogWriterLevel();
+if (!empty($sentryLogWriterLevel)) {
+    $GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = [
+        $sentryLogWriterLevel => [
+            \Networkteam\SentryClient\SentryLogWriter::class => [],
+        ],
+    ];
+}
+unset($sentryLogWriterLevel);


### PR DESCRIPTION
This is useful for example with powermail where SMTP errors are just logged
```php
// \In2code\Powermail\Controller\FormController
try {
   // send email
} catch (\Exception $exception) {
    $logger = ObjectUtility::getLogger(__CLASS__);
    $logger->critical('Mail could not be sent', [$exception->getMessage()]);
}
```