### PR TITLE
[FEATURE] Support TYPO3 proxy setting

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -33,6 +33,9 @@ class Client implements SingletonInterface
             $options['environment'] = ConfigurationService::getEnvironment();
             $options['error_types'] = E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_USER_DEPRECATED;
             $options['project_root'] = ConfigurationService::getProjectRoot();
+            if (isset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']) && $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'] !== '') {
+                $options['http_proxy'] = $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'];
+            }
             init($options);
 
             self::setUserContext();


### PR DESCRIPTION
For security reasons every request from within our server is routed over a proxy to the internet. Therefore we have to pass the proxy to all clients we use (e.g Guzzle). However, while the underlying Sentry library offers the `http_proxy` option, this package does not expose it. 

This PR adds support for Proxy by getting it from TYPO3 settings. This is transparent for the user and does not need any extra effort for configuration.