### PR TITLE
[BUGFIX] Ignore ImmediateResponseException

### DIFF
--- a/Classes/Service/ExceptionBlacklistService.php
+++ b/Classes/Service/ExceptionBlacklistService.php
@@ -13,6 +13,10 @@ class ExceptionBlacklistService
             return false;
         }
 
+        if ($exception instanceof \TYPO3\CMS\Core\Http\ImmediateResponseException) {
+            return false;
+        }
+
         if (!ConfigurationService::reportDatabaseConnectionErrors()) {
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
             if (!$queryBuilder->getConnection()->isConnected()) {


### PR DESCRIPTION
To cite TYPO3\CMS\Frontend\ContentObject\Exception\ProductionExceptionHandler:
 ImmediateResponseException should work similar to exit / die
 and must therefore not be handled by this ExceptionHandler.

Resolves: https://github.com/networkteam/sentry_client/issues/44