### PR TITLE
Fix error using log writer in console commands

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -81,7 +81,7 @@ class Client implements SingletonInterface
     {
         configureScope(
             function (Scope $scope): void {
-                $userContext['ip_address'] = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+                $userContext['ip_address'] = GeneralUtility::getIndpEnv('REMOTE_ADDR') ?: '127.0.0.1';
                 $reportUserInformation = ConfigurationService::getReportUserInformation();
                 if ($reportUserInformation !== ConfigurationService::USER_INFORMATION_NONE && isset($GLOBALS['TYPO3_REQUEST'])) {
                     $context = GeneralUtility::makeInstance(Context::class);


### PR DESCRIPTION
When using the log writer for logging errors in a console command the
following error is thrown:

In UserDataBag.php line 178: The "" value is not a valid IP address.

This comes from GeneralUtility::getIndpEnv('REMOTE_ADDR') which returns
an empty string as IP address on console. In this case the IP address of
localhost (127.0.0.1) is assigned instead.