### PR TITLE
Skip superfluous `QueryBuilder` creation

### DIFF
--- a/Classes/Service/ExceptionBlacklistService.php
+++ b/Classes/Service/ExceptionBlacklistService.php
@@ -25,8 +25,8 @@ class ExceptionBlacklistService
         }
 
         if (!ConfigurationService::reportDatabaseConnectionErrors()) {
-            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
-            if (!$queryBuilder->getConnection()->isConnected()) {
+            $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
+            if (!$connection->isConnected()) {
                 return false;
             }
         }


### PR DESCRIPTION
Only the `$connection` is used. Creating a `QueryBuilder` means unnecessary overhead.