### PR TITLE
[FEATURE] add request-id as a tag for tracing

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -128,11 +128,13 @@ class Client implements SingletonInterface
                 $requestId = $_SERVER['X-REQUEST-ID'] ?: $_SERVER['HTTP_X_REQUEST_ID'] ?: '';
 
                 $scope->setTags(
-                    [
+                    array_merge(
+                        [
                         'typo3_version' => GeneralUtility::makeInstance(Typo3Version::class)->getVersion(),
                         'typo3_mode' => $mode ?? '',
-                        'request_id' => $requestId,
-                    ]
+                        ],
+                        ($requestId ? ['request_id' => $requestId] : [])
+                    )
                 );
             }
         );

--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -125,10 +125,13 @@ class Client implements SingletonInterface
                     // deprecated in TYPO3 v11
                     $mode = TYPO3_MODE;
                 }
+                $requestId = $_SERVER['X-REQUEST-ID'] ?: $_SERVER['HTTP_X_REQUEST_ID'] ?: '';
+
                 $scope->setTags(
                     [
                         'typo3_version' => GeneralUtility::makeInstance(Typo3Version::class)->getVersion(),
                         'typo3_mode' => $mode ?? '',
+                        'request_id' => $requestId,
                     ]
                 );
             }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['YourVendor]['YourExtension]['Controller']['w
 * LogWriter Loglevel: If set, log messages are reported to Sentry
 * LogWriter Component blacklist
 
+### Request ID
+
+If the web server has set a request ID header `X-Request-Id`, this is transmitted as a tag to trace errors to logs.
+
 ## How to test if the extension works?
 
 ```typescript


### PR DESCRIPTION
A submitted  request-id is added as a tag to the scope. If it is not set, it is submitted empty. 