### PR TITLE
Fix empty ip error: in some circumstances the ip is an empty string

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -82,6 +82,9 @@ class Client implements SingletonInterface
         configureScope(
             function (Scope $scope): void {
                 $userContext['ip_address'] = IpAnonymizationUtility::anonymizeIp(GeneralUtility::getIndpEnv('REMOTE_ADDR') ?? '127.0.0.1');
+                if ($userContext['ip_address'] === '') {
+                    unset($userContext['ip_address']);
+                }
                 $reportUserInformation = ConfigurationService::getReportUserInformation();
                 if ($reportUserInformation !== ConfigurationService::USER_INFORMATION_NONE && isset($GLOBALS['TYPO3_REQUEST'])) {
                     $context = GeneralUtility::makeInstance(Context::class);


### PR DESCRIPTION
In some circumstances the ip is an empty string.
In my case it was on the CLI.
That results in an error in Sentry that is not the real error.

````
Error: Uncaught InvalidArgumentException: The "" value is not a valid IP address. in /app/vendor/sentry/sentry/src/UserDataBag.php:178
Stack trace:
#0 /app/vendor/sentry/sentry/src/UserDataBag.php(85): Sentry\UserDataBag->setIpAddress('')
#1 /app/vendor/sentry/sentry/src/State/Scope.php(192): Sentry\UserDataBag::createFromArray(Array)
#2 /app/public/typo3conf/ext/sentry_client/Classes/Client.php(113): Sentry\State\Scope->setUser(Array)
#3 /app/vendor/sentry/sentry/src/State/Hub.php(104): Networkteam\SentryClient\Client::Networkteam\SentryClient\{closure}(Object(Sentry\State\Scope))
#4 /app/vendor/sentry/sentry/src/functions.php(87): Sentry\State\Hub->configureScope(Object(Closure))
#5 /app/public/typo3conf/ext/sentry_client/Classes/Client.php(114): Sentry\configureScope(Object(Closure))
#6 /app/public/typo3conf/ext/sentry_client/Classes/Client.php(60): Networkteam\SentryClient\Client::setUserContext()
#7 /app/public/typo3conf/ext/sentry_client/Classes/SentryLogWriter.php(25): Networkteam\SentryClient\Client::init()
````