### PR TITLE
[BUGFIX] Prevent warning when fetching request ID header

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -127,7 +127,7 @@ class Client implements SingletonInterface
                 } else {
                     $mode = '';
                 }
-                $requestId = $_SERVER['X-REQUEST-ID'] ?: $_SERVER['HTTP_X_REQUEST_ID'] ?: '';
+                $requestId = $_SERVER['X-REQUEST-ID'] ?? $_SERVER['HTTP_X_REQUEST_ID'] ?? '';
                 $scope->setTags(
                     array_merge(
                         ['typo3_version' => GeneralUtility::makeInstance(Typo3Version::class)->getVersion()],


### PR DESCRIPTION
The following warning was logged before:

> Error handler (BE): PHP Warning: Undefined array key "X-REQUEST-ID"
> in typo3conf/ext/sentry_client/Classes/Client.php line 128