### PR TITLE
Add PSR-3 variable interpolation to log writer

### DIFF
--- a/Classes/SentryLogWriter.php
+++ b/Classes/SentryLogWriter.php
@@ -29,8 +29,13 @@ class SentryLogWriter extends AbstractWriter
                     $scope->setExtra('data', $record->getData());
                 }
                 $scope->setTag('source', 'logwriter');
+                
+                $message = $record->getMessage();
+                if (method_exists($this, 'interpolate')) {
+                    $message = $this->interpolate($message, $record->getData());
+                }
 
-                Client::captureMessage($record->getMessage(), $record->getLevel());
+                Client::captureMessage($message, $record->getLevel());
             });
         }
 


### PR DESCRIPTION
TYPO3 introduced an interpolate method in TYPO3 11 to implement
the PSR-3 variable interpolation in log messages. The interpolate
method must be called by the logger to replace placeholders in
the log message.

So if the method exists, which means we're in TYPO3 11, it is now
called in the logger.

Fixes #66 