### PR TITLE
[TASK] Use `ubuntu-latest` for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
`ubuntu-18.04` is old and outdated any GitHub does only provide a limited amount of runners with this version. Therefore, builds may get queued for a longer time. 

This change ensures, that `ubuntu-latest` is used for CI.