### PR TITLE
[TASK] Use TYPO3 HTTP configuration in sentry client

### DIFF
--- a/Classes/Service/SentryService.php
+++ b/Classes/Service/SentryService.php
@@ -37,6 +37,9 @@ class SentryService
             'environment' => ConfigurationService::getEnvironment(),
             'in_app_include' => [Environment::getExtensionsPath()],
             'http_proxy' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'] ?? null,
+            'http_ssl_verify_peer' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] ?? true,
+            'http_timeout' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['http_timeout'] ?? 5,
+            'http_connect_timeout' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'] ?? 2,
             'attach_stacktrace' => true,
             'before_send' => function (Event $event): Event {
                 return SentryLogWriter::cleanupStacktrace($event);

--- a/Classes/Service/SentryService.php
+++ b/Classes/Service/SentryService.php
@@ -37,9 +37,9 @@ class SentryService
             'environment' => ConfigurationService::getEnvironment(),
             'in_app_include' => [Environment::getExtensionsPath()],
             'http_proxy' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'] ?? null,
-            'http_ssl_verify_peer' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] ?? true,
-            'http_timeout' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['http_timeout'] ?? 5,
-            'http_connect_timeout' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'] ?? 2,
+            'http_ssl_verify_peer' => (bool)($GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] ?? true),
+            'http_timeout' => (int)($GLOBALS['TYPO3_CONF_VARS']['HTTP']['http_timeout'] ?? 5),
+            'http_connect_timeout' => (int)($GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'] ?? 2),
             'attach_stacktrace' => true,
             'before_send' => function (Event $event): Event {
                 return SentryLogWriter::cleanupStacktrace($event);


### PR DESCRIPTION
With version 4 of the Sentry SDK, Sentry now ships a simple and custom HTTP client which is based on curl. Using Guzzle as HTTP client does not seem possible, since Sentry SDK does use `php-http/discovery` anymore.

Basic HTTP configuration in $GLOBALS['TYPO3_CONF_VARS']['HTTP'] should be reflected to the Sentry HTTP client.

This change reflects the following TYPO3 HTTP options to the Sentry HTTP client:

* `verify`
* `http_timeout`
* `connect_timeout`

Closes #103