### PR TITLE
[BUGFIX] Only use http subkey for proxy setting

### DIFF
--- a/Classes/Service/SentryService.php
+++ b/Classes/Service/SentryService.php
@@ -36,7 +36,7 @@ class SentryService
             'release' => ConfigurationService::getRelease(),
             'environment' => ConfigurationService::getEnvironment(),
             'in_app_include' => [Environment::getExtensionsPath()],
-            'http_proxy' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'] ?? null,
+            'http_proxy' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']['http'] ?? null,
             'attach_stacktrace' => true,
             'before_send' => function (Event $event): Event {
                 return SentryLogWriter::cleanupStacktrace($event);

--- a/Classes/Service/SentryService.php
+++ b/Classes/Service/SentryService.php
@@ -31,12 +31,19 @@ class SentryService
             return false;
         }
 
+        $httpProxy = null;
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']['http'])) {
+            $httpProxy = $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']['http'];
+        } elseif (isset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'])) {
+            $httpProxy = $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'];
+        }
+
         $options = [
             'dsn' => $dsn,
             'release' => ConfigurationService::getRelease(),
             'environment' => ConfigurationService::getEnvironment(),
             'in_app_include' => [Environment::getExtensionsPath()],
-            'http_proxy' => $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']['http'] ?? null,
+            'http_proxy' => $httpProxy,
             'attach_stacktrace' => true,
             'before_send' => function (Event $event): Event {
                 return SentryLogWriter::cleanupStacktrace($event);


### PR DESCRIPTION
When using a "http_proxy" in Sentry / TYPO3, the real http proxy is now used. Otherwise cache flushing does not work anymore in PHP 8.3:

Uncaught TYPO3 Exception The option "http_proxy" with value array is expected to be of type "null" or "string", but is of type "array".
thrown in file vendor/symfony/options-resolver/OptionsResolver.php
in line 1060
