### PR TITLE
[BUGFIX] Consider config.contentObjectExceptionHandler.ignoreCodes 

### DIFF
--- a/Classes/Content/ProductionExceptionHandler.php
+++ b/Classes/Content/ProductionExceptionHandler.php
@@ -25,8 +25,8 @@ class ProductionExceptionHandler extends \TYPO3\CMS\Frontend\ContentObject\Excep
             throw $exception;
         }
 
-        $eventId = GeneralUtility::makeInstance(Client::class)->captureException($exception);
         $errorMessage = parent::handle($exception, $contentObject, $contentObjectConfiguration);
+        $eventId = GeneralUtility::makeInstance(Client::class)->captureException($exception);
 
         if (ConfigurationService::showEventId()) {
             return sprintf('%s Event: %s', $errorMessage, $eventId);


### PR DESCRIPTION
do not capture unhandled TYPO3 Content Production Handler Exception e.g. setting config.contentObjectExceptionHandler.ignoreCodes in TS tells TYPO3 Content Production Exception Handler not to handle Exceptions with configured Codes, but throw the Exception. In this case we do not want to capture the Exception in sentry