### PR TITLE
Add TYPO3 14 compatibility

### DIFF
--- a/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
+++ b/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
@@ -5,7 +5,7 @@ namespace Networkteam\SentryClient\EventListener;
 use Networkteam\SentryClient\Service\ConfigurationService;
 use Networkteam\SentryClient\Service\SentryService;
 use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
-use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
+use TYPO3\CMS\Backend\Toolbar\InformationStatus;
 use TYPO3\CMS\Core\Localization\LanguageService;
 
 class SystemInformationToolbarCollectorEventListener
@@ -21,7 +21,7 @@ class SystemInformationToolbarCollectorEventListener
             'Sentry',
             $label,
             'tx-sentryclient-sentry-glyph-light',
-            $isActive ? InformationStatus::STATUS_OK : InformationStatus::STATUS_ERROR
+            $isActive ? InformationStatus::OK : InformationStatus::ERROR
         );
 
         if ($isActive) {

--- a/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
+++ b/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
@@ -24,7 +24,7 @@ class SystemInformationToolbarCollectorEventListener
             'tx-sentryclient-sentry-glyph-light',
             $isActive
                 ? (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::OK : InformationStatus::STATUS_OK)
-                : (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::ERROR : InformationStatus::STATUS_ERROR)        );
+                : (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::ERROR : InformationStatus::STATUS_ERROR));
 
         if ($isActive) {
             $release = ConfigurationService::getRelease();

--- a/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
+++ b/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
@@ -5,7 +5,8 @@ namespace Networkteam\SentryClient\EventListener;
 use Networkteam\SentryClient\Service\ConfigurationService;
 use Networkteam\SentryClient\Service\SentryService;
 use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
-use TYPO3\CMS\Backend\Toolbar\InformationStatus;
+use TYPO3\CMS\Backend\Toolbar\Enumeration\InformationStatus;
+use TYPO3\CMS\Backend\Toolbar\InformationStatus as InformationStatusEnum;
 use TYPO3\CMS\Core\Localization\LanguageService;
 
 class SystemInformationToolbarCollectorEventListener
@@ -21,8 +22,9 @@ class SystemInformationToolbarCollectorEventListener
             'Sentry',
             $label,
             'tx-sentryclient-sentry-glyph-light',
-            $isActive ? InformationStatus::OK : InformationStatus::ERROR
-        );
+            $isActive
+                ? (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::OK : InformationStatus::STATUS_OK)
+                : (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::ERROR : InformationStatus::STATUS_ERROR)        );
 
         if ($isActive) {
             $release = ConfigurationService::getRelease();

--- a/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
+++ b/Classes/EventListener/SystemInformationToolbarCollectorEventListener.php
@@ -24,7 +24,8 @@ class SystemInformationToolbarCollectorEventListener
             'tx-sentryclient-sentry-glyph-light',
             $isActive
                 ? (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::OK : InformationStatus::STATUS_OK)
-                : (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::ERROR : InformationStatus::STATUS_ERROR));
+                : (enum_exists(InformationStatusEnum::class) ? InformationStatusEnum::ERROR : InformationStatus::STATUS_ERROR)
+        );
 
         if ($isActive) {
             $release = ConfigurationService::getRelease();

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   ],
   "require": {
     "php": "^8.0",
-    "typo3/cms-backend": "^14.0",
-    "typo3/cms-core": "^14.0",
-    "typo3/cms-frontend": "^14.0",
+    "typo3/cms-backend": "^11.0 || ^12.0 || ^13.0 || ^14.0",
+    "typo3/cms-core": "^11.0 || ^12.0 || ^13.0 || ^14.0",
+    "typo3/cms-frontend": "^11.0 || ^12.0 || ^13.0 || ^14.0",
     "sentry/sentry": "^4.6"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   ],
   "require": {
     "php": "^8.0",
-    "typo3/cms-backend": "^11.0 || ^12.0 || ^13.0 || ^14.0",
-    "typo3/cms-core": "^11.0 || ^12.0 || ^13.0 || ^14.0",
-    "typo3/cms-frontend": "^11.0 || ^12.0 || ^13.0 || ^14.0",
+    "typo3/cms-backend": "^14.0",
+    "typo3/cms-core": "^14.0",
+    "typo3/cms-frontend": "^14.0",
     "sentry/sentry": "^4.6"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   ],
   "require": {
     "php": "^8.0",
-    "typo3/cms-backend": "^11.0 || ^12.0 || ^13.0",
-    "typo3/cms-core": "^11.0 || ^12.0 || ^13.0",
-    "typo3/cms-frontend": "^11.0 || ^12.0 || ^13.0",
+    "typo3/cms-backend": "^11.0 || ^12.0 || ^13.0 || ^14.0",
+    "typo3/cms-core": "^11.0 || ^12.0 || ^13.0 || ^14.0",
+    "typo3/cms-frontend": "^11.0 || ^12.0 || ^13.0 || ^14.0",
     "sentry/sentry": "^4.6"
   },
   "extra": {


### PR DESCRIPTION
As InformationState class and enum has same name, I prefer removing old TYPO3 compatibility. Else you have to work with namespace aliases and version_compare.