### PR TITLE
Prevent Exception from getUri() in Cli-Context

### DIFF
--- a/Classes/Integration/Typo3Integration.php
+++ b/Classes/Integration/Typo3Integration.php
@@ -37,7 +37,7 @@ final class Typo3Integration implements IntegrationInterface
     private function processEvent(Event $event): void
     {
         $request = $this->getServerRequest();
-        if ($request instanceof ServerRequestInterface) {
+        if (!Environment::isCli() && $request instanceof ServerRequestInterface) {
             if (ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
                 $event->setTag('request_type', 'frontend');
                 $this->setUrl($event, $request);


### PR DESCRIPTION
Additionally check if we are running in cli.
Without it cli tasks which build a fake FE/BE Request fail.

fixes #121 